### PR TITLE
bugfix: sending different response for live and sandbox.

### DIFF
--- a/app/Library/sslcommerz/AbstractSslCommerz.php
+++ b/app/Library/sslcommerz/AbstractSslCommerz.php
@@ -93,7 +93,11 @@ abstract class AbstractSslCommerz implements SslCommerzInterface
         } else {
             if (isset($sslcz['GatewayPageURL']) && $sslcz['GatewayPageURL'] != "") {
                 // this is important to show the popup, return or echo to send json response back
-                $response = json_encode(['status' => 'success', 'data' => $sslcz['GatewayPageURL'], 'logo' => $sslcz['storeLogo']]);
+                if(isset($this->getApiUrl()) && $this->getApiUrl() == 'https://securepay.sslcommerz.com') {
+                   $response = json_encode(['status' => 'SUCCESS', 'data' => $sslcz['GatewayPageURL'], 'logo' => $sslcz['storeLogo']]);
+                } else {
+                    $response = json_encode(['status' => 'success', 'data' => $sslcz['GatewayPageURL'], 'logo' => $sslcz['storeLogo']]);
+                }
             } else {
                 $response = json_encode(['status' => 'fail', 'data' => null, 'message' => "JSON Data parsing error!"]);
             }


### PR DESCRIPTION
Live environment expects uppercase "SUCCESS" in return parameter, and lowercase "success" for sandbox.