### PR TITLE
bugfix for warning with curl v7.28.1 and later

### DIFF
--- a/app/Library/sslcommerz/SslCommerzNotification.php
+++ b/app/Library/sslcommerz/SslCommerzNotification.php
@@ -61,11 +61,11 @@ class SslCommerzNotification extends AbstractSslCommerz
                 curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
 
                  if ($this->config['connect_from_localhost']) {
-                     curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, false);
-                     curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);
+                     curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, 0);
+                     curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, 0);
                  } else {
-                     curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, true);
-                     curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, true);
+                     curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, 2);
+                     curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, 2);
                  }
 
 


### PR DESCRIPTION
From curl v 7.28.1 and later, this flag is treated differently. This pull request solves the warning "curl_setopt(): CURLOPT_SSL_VERIFYHOST no longer accepts the value 1, value 2 will be used instead".

[0] https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html